### PR TITLE
documentation drive: add an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,19 @@ A [multiserver](https://github.com/ssbc/multiserver) plugin that facilitates com
 
 This module requires a bluetooth-manager as a parameter for taking care of connections, disconnections and opening connection streams. This is to allow this plugin to be used on different platforms (e.g. mobile, linux, windows) with the same interface.
 
-For an example implementation of the bluetooth-manager, see [ssb-bluetooth-manager](https://github.com/Happy0/ssb-bluetooth-manager)
+## example
+
+This must be used with an implementation of the bluetooth-manager, see [ssb-bluetooth-manager](https://github.com/Happy0/ssb-bluetooth-manager)
+
+
+``` js
+var Bluetooth = require('multiserver-bluetooth')
+var BluetoothManager = require('ssb-bluetooth-manager')
+
+var bt = Bluetooth({
+  bluetoothManager: BluetoothManager(),
+  scope: ... //your scope, default is public
+})
+
+bt.stringify(scope) => "bt:<your_bt_mac_address>"
+```


### PR DESCRIPTION
I was documenting multiserver and thought it would be better to put the documentation for this module (which is linked from multiserver) into this module's readme. I notice that it needs a BluetoothManager but the bluetooth manager doesn't actually have any config.

Hmm, if this was running on a desktop rather than react native it would have a different manager, but for now there is only one? I notice it's called "ssb-bluetooth-manager" but it doesn't seem to use any ssb- apis?